### PR TITLE
Fix spelling of governor in script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # govern
-Linux process governer: a simple shell script to manage multiple processes
+Linux process governor: a simple shell script to manage multiple processes
 
 ## What govern.sh is
 

--- a/govern.sh
+++ b/govern.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # govern.sh
-#  Linux process governer: a simple shell script to manage multiple processes
+#  Linux process governor: a simple shell script to manage multiple processes
 #
 # Copyright (c) 2023 Satoshi Takahashi, all rights reserved.
 #


### PR DESCRIPTION
## Summary
- Replace misspelled "governer" with "governor" in govern.sh and README

## Testing
- `bash -n govern.sh`
- `markdownlint README.md` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6897f5212c2c832ca970bb57d86f0e23