### PR TITLE
Fixed bug of not accepting a configuration file

### DIFF
--- a/govern.sh
+++ b/govern.sh
@@ -117,7 +117,7 @@ do_cmd()
 
 # glob conf files
 # https://programwiz.org/2021/05/09/shellscript-in-bash-how-to-files-loop/
-mapfile -t CONF < <(find . -maxdepth 1 -name '*.conf.sh' -print)
+mapfile -t CONF < <(find . -maxdepth 1 -type f -name '*.conf.sh' -printf '%f\n' | sort)
 
 # determine whether specific conf file is selected or not
 # https://qiita.com/Hayao0819/items/0e04b39b0804a0d16020

--- a/local/oem7.conf.sh
+++ b/local/oem7.conf.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=bash
+# govern.sh configuration file (*.conf.sh) located in ~/local/
+#
+# Environment variables of CMD, ARGS, and MARK should be specified in 
+# this configuration file.
+#   CMD:  the command file path to execute
+#   ARGS: the arguments required for the command (as an array)
+#   MARK: the process feature that is uniquely determind with ps command
+
+HOST=192.168.0.1
+RPORT=3002       # OEM729 ICOM2 (OEM7 raw)
+LPORT=2000
+MSG="\
+1005(1),\
+1019,\
+1020,\
+1033(1),\
+1041,\
+1042,\
+1044,\
+1045,\
+1046,\
+1077(1),\
+1087(1),\
+1097(1),\
+1117(1),\
+1127(1),\
+1137(1),\
+1230\
+"
+POSITION="34.4401061 132.4147804 233.362"
+ANTENNA="JAVGRANT_G5T NONE,,0"
+RECEIVER="NOV OEM729,OM7MR0814RN0000,"
+
+MARK="tcpcli://$HOST:$RPORT#nov"
+CMD=$HOME/bin/str2str
+ARGS=(-in "$MARK" \
+    -out "tcpsvr://:$LPORT" \
+    -msg "$MSG" \
+    -p   $POSITION \
+    -i   "$RECEIVER" \
+    -a   "$ANTENNA")
+
+#EOF

--- a/local/oem7.conf.sh
+++ b/local/oem7.conf.sh
@@ -5,7 +5,7 @@
 # this configuration file.
 #   CMD:  the command file path to execute
 #   ARGS: the arguments required for the command (as an array)
-#   MARK: the process feature that is uniquely determind with ps command
+#   MARK: the process feature that is uniquely determined with ps command
 
 HOST=192.168.0.1
 RPORT=3002       # OEM729 ICOM2 (OEM7 raw)

--- a/local/sample.conf.sh
+++ b/local/sample.conf.sh
@@ -9,15 +9,11 @@
 
 # With this example configuration, govern.sh executes:
 # ---
-#  $HOME/exec/str2str -in serial://ttyF9P -a "JAVGRANT_G5T NONE" -out tcpserver://:2001 -b 1
+#  $HOME/bin/str2str -in serial://ttyF9P -a "JAVGRANT_G5T NONE" -out tcpserver://:2001 -b 1
 # ---
 
-LPORT=2001
-DEV=ttyF9P
-
-if [ ! -e /dev/$DEV ]; then echo "$0: no /dev/$DEV"; exit 1; fi
-MARK="serial://$DEV:230400"
-CMD=$HOME/exec/str2str
-ARGS=(-in "$MARK" -a "JAVGRANT_G5T NONE" -out "tcpsvr://:$LPORT" -b 1)
+MARK="serial://ttyF9P:230400"
+CMD=$HOME/bin/str2str
+ARGS=(-in "$MARK" -a "JAVGRANT_G5T NONE" -out "tcpsvr://:2001" -b 1)
 
 # EOF


### PR DESCRIPTION
Add sample file oem7.conf.sh for describing arguments with spaces.

For use this with str2str, please note that double-quotes are needed for the receiver and antenna descriptions (-i and -ia), while please do not add double-quotes for the position description (-p).